### PR TITLE
feat: add scopesUpdated to attr sub

### DIFF
--- a/internal/graph/generated.go
+++ b/internal/graph/generated.go
@@ -300,9 +300,10 @@ type ComplexityRoot struct {
 	}
 
 	SubAttributesPayload struct {
-		Attribute func(childComplexity int) int
-		Done      func(childComplexity int) int
-		IsNew     func(childComplexity int) int
+		Attribute     func(childComplexity int) int
+		Done          func(childComplexity int) int
+		IsNew         func(childComplexity int) int
+		ScopesUpdated func(childComplexity int) int
 	}
 
 	Subscription struct {
@@ -1474,6 +1475,13 @@ func (e *executableSchema) Complexity(typeName, field string, childComplexity in
 		}
 
 		return e.complexity.SubAttributesPayload.IsNew(childComplexity), true
+
+	case "SubAttributesPayload.scopesUpdated":
+		if e.complexity.SubAttributesPayload.ScopesUpdated == nil {
+			break
+		}
+
+		return e.complexity.SubAttributesPayload.ScopesUpdated(childComplexity), true
 
 	case "Subscription.changes":
 		if e.complexity.Subscription.Changes == nil {
@@ -9608,6 +9616,47 @@ func (ec *executionContext) fieldContext_SubAttributesPayload_done(ctx context.C
 	return fc, nil
 }
 
+func (ec *executionContext) _SubAttributesPayload_scopesUpdated(ctx context.Context, field graphql.CollectedField, obj *mgen.SubAttributesPayload) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_SubAttributesPayload_scopesUpdated(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.ScopesUpdated, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		return graphql.Null
+	}
+	res := resTmp.([]string)
+	fc.Result = res
+	return ec.marshalOString2ᚕstringᚄ(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_SubAttributesPayload_scopesUpdated(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "SubAttributesPayload",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type String does not have child fields")
+		},
+	}
+	return fc, nil
+}
+
 func (ec *executionContext) _SubAttributesPayload_isNew(ctx context.Context, field graphql.CollectedField, obj *mgen.SubAttributesPayload) (ret graphql.Marshaler) {
 	fc, err := ec.fieldContext_SubAttributesPayload_isNew(ctx, field)
 	if err != nil {
@@ -10023,6 +10072,8 @@ func (ec *executionContext) fieldContext_Subscription_scopedAttributes(ctx conte
 				return ec.fieldContext_SubAttributesPayload_attribute(ctx, field)
 			case "done":
 				return ec.fieldContext_SubAttributesPayload_done(ctx, field)
+			case "scopesUpdated":
+				return ec.fieldContext_SubAttributesPayload_scopesUpdated(ctx, field)
 			case "isNew":
 				return ec.fieldContext_SubAttributesPayload_isNew(ctx, field)
 			}
@@ -10100,6 +10151,8 @@ func (ec *executionContext) fieldContext_Subscription_globalAttributes(ctx conte
 				return ec.fieldContext_SubAttributesPayload_attribute(ctx, field)
 			case "done":
 				return ec.fieldContext_SubAttributesPayload_done(ctx, field)
+			case "scopesUpdated":
+				return ec.fieldContext_SubAttributesPayload_scopesUpdated(ctx, field)
 			case "isNew":
 				return ec.fieldContext_SubAttributesPayload_isNew(ctx, field)
 			}
@@ -15249,6 +15302,10 @@ func (ec *executionContext) _SubAttributesPayload(ctx context.Context, sel ast.S
 			if out.Values[i] == graphql.Null {
 				invalids++
 			}
+		case "scopesUpdated":
+
+			out.Values[i] = ec._SubAttributesPayload_scopesUpdated(ctx, field, obj)
+
 		case "isNew":
 
 			out.Values[i] = ec._SubAttributesPayload_isNew(ctx, field, obj)

--- a/internal/graph/mgen/models_gen.go
+++ b/internal/graph/mgen/models_gen.go
@@ -279,6 +279,13 @@ type SubAttributesPayload struct {
 	Attribute *models.Attribute `json:"attribute"`
 	// done indicates that the state has finished synchorizing.
 	Done bool `json:"done"`
+	// scopesUpdated is the list of the scope IDs matching the subscription that have
+	// been sent and are done *synced). This can only sent along with done == true.
+	// If done == true and the list is empty, then no scopes matched the
+	// subscription. The list must be sent if done == true. Done can be true and
+	// scopesUpdated can contain IDs even if no attributes were sent. In this case,
+	// the scopes matched were empty.
+	ScopesUpdated []string `json:"scopesUpdated"`
 	// isNew returns true if the Attribute for key and nodeID was just created.
 	IsNew bool `json:"isNew"`
 }

--- a/internal/graph/schema/scope.graphqls
+++ b/internal/graph/schema/scope.graphqls
@@ -111,6 +111,16 @@ type SubAttributesPayload {
   done: Boolean!
 
   """
+  scopesUpdated is the list of the scope IDs matching the subscription that have
+  been sent and are done *synced). This can only sent along with done == true.
+  If done == true and the list is empty, then no scopes matched the
+  subscription. The list must be sent if done == true. Done can be true and
+  scopesUpdated can contain IDs even if no attributes were sent. In this case,
+  the scopes matched were empty.
+  """
+  scopesUpdated: [String!]
+
+  """
   isNew returns true if the Attribute for key and nodeID was just created.
   """
   isNew: Boolean!

--- a/internal/graph/service.resolvers.go
+++ b/internal/graph/service.resolvers.go
@@ -21,7 +21,7 @@ func (r *mutationResolver) RegisterService(ctx context.Context, input mgen.Regis
 
 	s, t, err := rt.RegisterService(ctx, input.Name, true)
 	if err != nil {
-		return nil, errs.Wrap(err, "transition step")
+		return nil, errs.Wrap(err, "register service")
 	}
 
 	return &mgen.RegisterServicePayload{Service: s, SessionToken: t}, nil

--- a/internal/graph/user.resolvers.go
+++ b/internal/graph/user.resolvers.go
@@ -17,7 +17,7 @@ func (r *mutationResolver) Login(ctx context.Context, input mgen.LoginInput) (*m
 
 	u, s, err := rt.Login(ctx, input.Username, input.Password)
 	if err != nil {
-		return nil, errs.Wrap(err, "transition step")
+		return nil, errs.Wrap(err, "log in user")
 	}
 
 	return &mgen.LoginPayload{User: u, SessionToken: s}, nil

--- a/internal/runtime/change.go
+++ b/internal/runtime/change.go
@@ -396,10 +396,8 @@ func (r *Runtime) SubChanges(ctx context.Context) (<-chan *models.ChangePayload,
 		} else {
 			// Wait for end of connection
 			<-ctx.Done()
-
-			r.Lock()
-			defer r.Unlock()
 		}
+		r.Lock()
 
 		n := 0
 
@@ -414,7 +412,10 @@ func (r *Runtime) SubChanges(ctx context.Context) (<-chan *models.ChangePayload,
 
 		if len(r.changesSubs[p.ID]) == 0 {
 			delete(r.changesSubs, p.ID)
+			r.Unlock()
 			r.propagateHook(ctx, mgen.EventTypeParticipantDisconnect, p.ID, p)
+		} else {
+			r.Unlock()
 		}
 	}()
 

--- a/internal/runtime/runtime.go
+++ b/internal/runtime/runtime.go
@@ -42,7 +42,7 @@ func Start(ctx context.Context) (*Runtime, error) {
 
 	s, _, err := r.RegisterService(ctx, "system", false)
 	if err != nil {
-		return nil, errors.Wrap(err, "transition step")
+		return nil, errors.Wrap(err, "register service")
 	}
 
 	r.SystemService = s

--- a/internal/runtime/scope.go
+++ b/internal/runtime/scope.go
@@ -356,16 +356,33 @@ func (r *Runtime) SubScopedAttributes(
 		r.Unlock()
 
 		var pls []*mgen.SubAttributesPayload
+
 		for i, attr := range attrs {
-			pls = append(pls, &mgen.SubAttributesPayload{
+			done := l == i+1
+			p := &mgen.SubAttributesPayload{
 				Attribute: attr,
-				Done:      l == i+1,
-			})
+				Done:      done,
+			}
+
+			if done {
+				p.ScopesUpdated = make([]string, 0, len(c.scopes))
+				for id := range c.scopes {
+					p.ScopesUpdated = append(p.ScopesUpdated, id)
+				}
+			}
+
+			pls = append(pls, p)
 		}
 
 		if len(attrs) == 0 {
+			scopesUpdated := make([]string, 0, len(c.scopes))
+			for id := range c.scopes {
+				scopesUpdated = append(scopesUpdated, id)
+			}
+
 			pls = append(pls, &mgen.SubAttributesPayload{
-				Done: true,
+				Done:          true,
+				ScopesUpdated: scopesUpdated,
 			})
 		}
 
@@ -441,12 +458,23 @@ func (r *Runtime) pushAttributesForScopedAttributes(ctx context.Context, attrs [
 		l := len(attrs)
 
 		var pls []*mgen.SubAttributesPayload
+
 		for i, attr := range attrs {
-			pls = append(pls, &mgen.SubAttributesPayload{
+			done := l == i+1
+			p := &mgen.SubAttributesPayload{
 				Attribute: attr,
 				IsNew:     attr.Version == 1,
-				Done:      l == i+1,
-			})
+				Done:      done,
+			}
+
+			if done {
+				p.ScopesUpdated = make([]string, 0, len(sub.scopes))
+				for id := range sub.scopes {
+					p.ScopesUpdated = append(p.ScopesUpdated, id)
+				}
+			}
+
+			pls = append(pls, p)
 		}
 
 		sub.Send(pls)

--- a/lib/tajriba/src/documents/scopes.graphql
+++ b/lib/tajriba/src/documents/scopes.graphql
@@ -69,6 +69,7 @@ subscription ScopedAttributes($input: [ScopedAttributesInput!]!) {
       ...attributeFields
     }
     isNew
+    scopesUpdated
     done
   }
 }

--- a/lib/tajriba/src/generated/graphql.ts
+++ b/lib/tajriba/src/generated/graphql.ts
@@ -848,6 +848,15 @@ export type SubAttributesPayload = {
   done: Scalars["Boolean"];
   /** isNew returns true if the Attribute for key and nodeID was just created. */
   isNew: Scalars["Boolean"];
+  /**
+   * scopesUpdated is the list of the scope IDs matching the subscription that have
+   * been sent and are done *synced). This can only sent along with done == true.
+   * If done == true and the list is empty, then no scopes matched the
+   * subscription. The list must be sent if done == true. Done can be true and
+   * scopesUpdated can contain IDs even if no attributes were sent. In this case,
+   * the scopes matched were empty.
+   */
+  scopesUpdated?: Maybe<Array<Scalars["String"]>>;
 };
 
 export type Subscription = {
@@ -2182,6 +2191,7 @@ export type ScopedAttributesSubscription = {
   scopedAttributes: {
     __typename: "SubAttributesPayload";
     isNew: boolean;
+    scopesUpdated?: Array<string> | null;
     done: boolean;
     attribute?: {
       __typename: "Attribute";
@@ -8633,6 +8643,10 @@ export const ScopedAttributesDocument = {
                   },
                 },
                 { kind: "Field", name: { kind: "Name", value: "isNew" } },
+                {
+                  kind: "Field",
+                  name: { kind: "Name", value: "scopesUpdated" },
+                },
                 { kind: "Field", name: { kind: "Name", value: "done" } },
               ],
             },


### PR DESCRIPTION
This add a scopesUpdated field to the payload of an attributes sub. It helps the subscriber track which scopes have been synced up.